### PR TITLE
docs(v5.9.1.tags): allow % in tag names + updated error codes (#1788)

### DIFF
--- a/v5.9.1/api-reference/campaigns.md
+++ b/v5.9.1/api-reference/campaigns.md
@@ -823,7 +823,7 @@ curl -X POST https://example.com/api.php \
 | Command   | String | Yes      | API command: `tag.create`             |
 | SessionID | String | No       | Session ID obtained from login        |
 | APIKey    | String | No       | API key for authentication            |
-| Tag       | String | Yes      | Tag name (letters, numbers, spaces, hyphens, underscores only) |
+| Tag       | String | Yes      | Tag name. Allowed characters: letters, numbers, spaces, hyphens, underscores, percent signs (`%`). Leading and trailing whitespace is trimmed automatically. |
 
 ::: code-group
 
@@ -857,7 +857,7 @@ curl -X POST https://example.com/api.php \
 0: Success
 1: Missing required parameter (Tag)
 2: Tag already exists in the system
-3: Invalid tag format (only letters, numbers, spaces, hyphens and underscores allowed)
+3: Invalid tag format (only letters, numbers, spaces, hyphens, underscores and percent signs allowed)
 4: Tag cannot be empty after trimming whitespace
 ```
 
@@ -880,7 +880,7 @@ curl -X POST https://example.com/api.php \
 | SessionID | String  | No       | Session ID obtained from login        |
 | APIKey    | String  | No       | API key for authentication            |
 | TagID     | Integer | Yes      | ID of the tag to update               |
-| Tag       | String  | Yes      | New tag name (letters, numbers, spaces, hyphens, underscores only) |
+| Tag       | String  | Yes      | New tag name. Allowed characters: letters, numbers, spaces, hyphens, underscores, percent signs (`%`). Leading and trailing whitespace is trimmed automatically. |
 
 ::: code-group
 
@@ -914,7 +914,7 @@ curl -X POST https://example.com/api.php \
 0: Success
 1: Missing required parameter (TagID)
 2: Missing required parameter (Tag)
-3: Invalid tag format (only letters, numbers, spaces, hyphens and underscores allowed)
+3: Invalid tag format (only letters, numbers, spaces, hyphens, underscores and percent signs allowed)
 4: Tag cannot be empty after trimming whitespace
 ```
 

--- a/v5.9.1/api-reference/campaigns.md
+++ b/v5.9.1/api-reference/campaigns.md
@@ -857,7 +857,7 @@ curl -X POST https://example.com/api.php \
 0: Success
 1: Missing required parameter (Tag)
 2: Tag already exists in the system
-3: Invalid tag format (only letters, numbers, spaces, hyphens, underscores and percent signs allowed)
+3: Invalid tag format (only letters, numbers, spaces, hyphens and underscores allowed, and percent signs)
 4: Tag cannot be empty after trimming whitespace
 ```
 
@@ -914,7 +914,7 @@ curl -X POST https://example.com/api.php \
 0: Success
 1: Missing required parameter (TagID)
 2: Missing required parameter (Tag)
-3: Invalid tag format (only letters, numbers, spaces, hyphens, underscores and percent signs allowed)
+3: Invalid tag format (only letters, numbers, spaces, hyphens and underscores allowed, and percent signs)
 4: Tag cannot be empty after trimming whitespace
 ```
 

--- a/v5.9.1/api-reference/subscribers.md
+++ b/v5.9.1/api-reference/subscribers.md
@@ -1754,7 +1754,7 @@ curl -X POST https://example.com/api.php \
 0: Success
 1: Missing ListID parameter
 2: Missing TagName parameter
-3: Invalid tag format (only letters, numbers, spaces, hyphens, underscores and percent signs allowed)
+3: Invalid tag format (only letters, numbers, spaces, hyphens and underscores allowed, and percent signs)
 4: Invalid ListID
 5: Tag name already exists
 ```
@@ -1817,7 +1817,7 @@ curl -X POST https://example.com/api.php \
 0: Success
 1: Missing ListID parameter
 2: Missing TagID parameter
-3: Invalid tag format (only letters, numbers, spaces, hyphens, underscores and percent signs allowed)
+3: Invalid tag format (only letters, numbers, spaces, hyphens and underscores allowed, and percent signs)
 4: Invalid ListID, Invalid TagID, or Tag cannot be empty after trimming whitespace
 5: Tag name already exists
 ```

--- a/v5.9.1/api-reference/subscribers.md
+++ b/v5.9.1/api-reference/subscribers.md
@@ -1754,9 +1754,12 @@ curl -X POST https://example.com/api.php \
 0: Success
 1: Missing ListID parameter
 2: Missing TagName parameter
-3: Invalid ListID
-4: Tag name already exists
+3: Invalid tag format (only letters, numbers, spaces, hyphens, underscores and percent signs allowed)
+4: Invalid ListID
+5: Tag name already exists
 ```
+
+Tag names are trimmed of leading and trailing whitespace and must contain only letters, numbers, spaces, hyphens, underscores, or percent signs (`%`).
 
 :::
 
@@ -1814,10 +1817,12 @@ curl -X POST https://example.com/api.php \
 0: Success
 1: Missing ListID parameter
 2: Missing TagID parameter
-3: Invalid ListID
-4: Invalid TagID
+3: Invalid tag format (only letters, numbers, spaces, hyphens, underscores and percent signs allowed)
+4: Invalid ListID, Invalid TagID, or Tag cannot be empty after trimming whitespace
 5: Tag name already exists
 ```
+
+When provided, the tag name is trimmed of leading and trailing whitespace and must contain only letters, numbers, spaces, hyphens, underscores, or percent signs (`%`).
 
 :::
 


### PR DESCRIPTION
## Summary

Updates the v5.9.1 API reference pages to reflect the centralized tag-name validation introduced in octeth/oempro#1788.

- `Create a Tag` / `Update a Tag` (campaigns.md) — adds percent (`%`) to the Tag parameter's allowed-character description and to the error-code 3 listing.
- `Create a Subscriber Tag` / `Update a Subscriber Tag` (subscribers.md) — same updates, plus a one-line note that the validator trims surrounding whitespace.

## Why

The backend PR (octeth/oempro#1788) replaces inline regex `/^[a-zA-Z0-9\s_-]+$/` with a centralized `Tags::ValidateTagName()` whose allowed set is `/^[a-zA-Z0-9\s_%-]+$/`. The docs need to match so API consumers know `%` is now valid in tag names.

Pre-existing parameter-name inconsistencies in the subscribers.md `subscriber.tags.*` sections (e.g. `TagName` / `TagDescription` not matching the actual `tag` parameter) are out of scope here — happy to clean those up in a follow-up if useful.

## Test Plan

- [ ] Visual review of the rendered VitePress pages on the docs preview site.
- [ ] Confirm the error-codes block in each section accurately reflects what the backend now returns.

Related: octeth/oempro#1788
