### PR TITLE
docs(api): document usergroup.update persisted fields + DefaultRateLimits merge (#1985)

### DIFF
--- a/v5.9.1/api-reference/users.md
+++ b/v5.9.1/api-reference/users.md
@@ -1155,6 +1155,10 @@ curl -X GET https://example.com/api/v1/users.status \
 | RelThemeID | Integer | Yes | Theme ID |
 | ForceUnsubscriptionLink | String | Yes | 'Enabled' or 'Disabled' |
 | ForceRejectOptLink | String | Yes | 'Enabled' or 'Disabled' |
+| DefaultRateLimits | String | No | JSON-encoded rate limits with `SMS` and `EmailGateway` buckets, each containing `Minute`/`Hour`/`Day`/`Week`/`Month`/`Year` integer counts (`-1` = unlimited). Posted values are deep-merged over the canonical defaults, so a partial payload (only one bucket, or only some intervals) preserves the missing keys at `-1`. Omit to store the full all-`-1` defaults. |
+| CustomEmailHeaders | String | No | JSON-encoded SMTP header overrides for users in this group (e.g. `{"Add":{"X-Header":"value"},"Remove":["X-Other"]}`). |
+| Options | Object | No | JSON object of per-group options (e.g. `TargetDeliveryServerID_Marketing`, `EmailGatewayDNSTemplate`, `DefaultSenderDomain`, `EnableSenderInfo`). Pass as an object — the endpoint JSON-encodes it. |
+| SubscriptionPlan | String | No | Subscription plan identifier for the group. |
 
 ::: code-group
 
@@ -1239,6 +1243,10 @@ curl -X POST https://example.com/api.php \
 | RelThemeID | Integer | Yes | Theme ID |
 | ForceUnsubscriptionLink | String | Yes | 'Enabled' or 'Disabled' |
 | ForceRejectOptLink | String | Yes | 'Enabled' or 'Disabled' |
+| DefaultRateLimits | String | No | JSON-encoded rate limits with `SMS` and `EmailGateway` buckets, each containing `Minute`/`Hour`/`Day`/`Week`/`Month`/`Year` integer counts (`-1` = unlimited). Posted values are deep-merged over the canonical defaults, so a partial payload (only one bucket, or only some intervals) preserves the missing keys at `-1`. Omit the field entirely to keep the existing row's value. |
+| CustomEmailHeaders | String | No | JSON-encoded SMTP header overrides for users in this group (e.g. `{"Add":{"X-Header":"value"},"Remove":["X-Other"]}`). Omit to keep the existing row's value. |
+| Options | Object | No | JSON object of per-group options (e.g. `TargetDeliveryServerID_Marketing`, `EmailGatewayDNSTemplate`, `DefaultSenderDomain`, `EnableSenderInfo`). Pass as an object — the endpoint JSON-encodes it. Omit to keep the existing row's value. |
+| SubscriptionPlan | String | No | Subscription plan identifier for the group. Omit to keep the existing row's value. |
 
 ::: code-group
 
@@ -1258,7 +1266,8 @@ curl -X POST https://example.com/api.php \
     "LimitEmailSendPerDay": 10000,
     "RelThemeID": 1,
     "ForceUnsubscriptionLink": "Enabled",
-    "ForceRejectOptLink": "Enabled"
+    "ForceRejectOptLink": "Enabled",
+    "DefaultRateLimits": "{\"SMS\":{\"Minute\":-1,\"Hour\":-1,\"Day\":-1,\"Week\":-1,\"Month\":-1,\"Year\":-1},\"EmailGateway\":{\"Minute\":100,\"Hour\":5000,\"Day\":-1,\"Week\":-1,\"Month\":-1,\"Year\":-1}}"
   }'
 ```
 


### PR DESCRIPTION
## Summary

Updates `v5.9.1/api-reference/users.md` to reflect the API changes in [octeth/oempro#2041](https://github.com/octeth/oempro/pull/2041).

- `usergroup.update` now persists `DefaultRateLimits`, `CustomEmailHeaders`, `Options`, and `SubscriptionPlan` — added all four to the Request Body Parameters table with an "omit to keep existing row's value" note.
- `DefaultRateLimits` description (in both `usergroup.create` and `usergroup.update`) explains the deep-merge against canonical defaults so a partial payload can't drop the SMS or EmailGateway bucket.
- Example request body in `usergroup.update` now includes a partial `DefaultRateLimits` value to demonstrate the merge behavior.

## Test Plan

- [ ] Build the VitePress site locally; confirm the `Update User Group` and `Create User Group` sections render the new rows without table-formatting glitches.

Related: octeth/oempro#1985, octeth/oempro#2041